### PR TITLE
chore: Fix cargo-deny configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,12 +27,6 @@ jobs:
         with:
           clang-format-version: 15
 
-  cargo-deny:
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v4
-      - uses: EmbarkStudios/cargo-deny-action@v1
-
   clippy:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -61,6 +55,33 @@ jobs:
       - uses: actions/checkout@v4
       - id: step2
         run: echo "version=`cat Cargo.toml | sed -n 's/rust-version = "\(.*\)"/\1/p'`" >> "$GITHUB_OUTPUT"
+
+  cargo-deny:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: aarch64-apple-darwin
+          - target: i686-pc-windows-gnu
+          - target: i686-pc-windows-msvc
+          - target: i686-unknown-linux-gnu
+          - target: x86_64-apple-darwin
+          - target: x86_64-pc-windows-gnu
+          - target: x86_64-pc-windows-msvc
+          - target: x86_64-unknown-linux-gnu
+          - target: x86_64-unknown-linux-musl
+
+    name: cargo-deny ${{ matrix.target }}
+    runs-on: ubuntu-22.04
+    needs: find-msrv
+    steps:
+      - uses: actions/checkout@v4
+      - uses: EmbarkStudios/cargo-deny-action@v1
+        with:
+          rust-version: ${{ needs.find-msrv.outputs.version }}
+          log-level: error
+          command: check
+          arguments: --target  ${{ matrix.target }}
 
   test:
     runs-on: ${{ matrix.os }}

--- a/deny.toml
+++ b/deny.toml
@@ -41,11 +41,7 @@ wildcards = "deny"
 highlight = "all"
 allow = []
 deny = []
-skip = [
-    "event-listener",
-    "event-listener-strategy",
-    "syn",
-]
+skip = []
 skip-tree = []
 
 [sources]

--- a/deny.toml
+++ b/deny.toml
@@ -41,7 +41,11 @@ wildcards = "deny"
 highlight = "all"
 allow = []
 deny = []
-skip = []
+skip = [
+    "async-channel",
+    "event-listener",
+    "syn"
+]
 skip-tree = []
 
 [sources]

--- a/deny.toml
+++ b/deny.toml
@@ -1,19 +1,25 @@
-targets = []
+[graph]
+# Note: running just `cargo deny check` without a `--target` can result in
+# false positives due to https://github.com/EmbarkStudios/cargo-deny/issues/324
+targets = [
+  { triple = "aarch64-apple-darwin" },
+  { triple = "i686-pc-windows-gnu" },
+  { triple = "i686-pc-windows-msvc" },
+  { triple = "i686-unknown-linux-gnu" },
+  { triple = "x86_64-apple-darwin" },
+  { triple = "x86_64-pc-windows-gnu" },
+  { triple = "x86_64-pc-windows-msvc" },
+  { triple = "x86_64-unknown-linux-gnu" },
+  { triple = "x86_64-unknown-linux-musl" },
+]
 all-features = true
-no-default-features = false
-feature-depth = 1
 
 [advisories]
 db-path = "~/.cargo/advisory-db"
 db-urls = ["https://github.com/rustsec/advisory-db"]
-vulnerability = "deny"
-unmaintained = "warn"
-yanked = "warn"
-notice = "warn"
 ignore = []
 
 [licenses]
-unlicensed = "deny"
 allow = [
     "Apache-2.0",
     "Apache-2.0 WITH LLVM-exception",
@@ -22,10 +28,6 @@ allow = [
     "ISC",
     "MIT",
 ]
-deny = []
-copyleft = "warn"
-allow-osi-fsf-free = "neither"
-default = "deny"
 confidence-threshold = 0.8
 exceptions = [
     { name = "unicode-ident", allow = [
@@ -34,19 +36,14 @@ exceptions = [
 ]
 
 [bans]
-multiple-versions = "warn"
-wildcards = "allow"
+multiple-versions = "deny"
+wildcards = "deny"
 highlight = "all"
-workspace-default-features = "allow"
-external-default-features = "allow"
 allow = []
 deny = []
-
 skip = []
 skip-tree = []
 
 [sources]
-unknown-registry = "warn"
-unknown-git = "warn"
-allow-registry = ["https://github.com/rust-lang/crates.io-index"]
-allow-git = []
+unknown-registry = "deny"
+unknown-git = "deny"

--- a/deny.toml
+++ b/deny.toml
@@ -42,9 +42,9 @@ highlight = "all"
 allow = []
 deny = []
 skip = [
-    "async-channel",
     "event-listener",
-    "syn"
+    "event-listener-strategy",
+    "syn",
 ]
 skip-tree = []
 


### PR DESCRIPTION
Blocks #7 

This makes cargo-deny stricter, but also more in line with the rest of the ecosystem.