### PR TITLE
fix: Remove paste from Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -648,12 +648,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
 name = "pin-project-lite"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"


### PR DESCRIPTION
Not sure what happened here but paste was still in our Cargo.lock despite it not being used anymore.