### PR TITLE
fix: Update Corrosion to 0.5.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ if (ACCESSKIT_BUILD_LIBRARIES)
     FetchContent_Declare(
         Corrosion
         GIT_REPOSITORY https://github.com/corrosion-rs/corrosion.git
-        GIT_TAG v0.4.7
+        GIT_TAG v0.5.1
     )
     FetchContent_MakeAvailable(Corrosion)
 


### PR DESCRIPTION
I found out that I was using an older Rust toolchain on my development environment (1.82) and that the most recent stable toolchain was actually ignored. By forcing the use of the latest stable I was able to reproduce the failure we see on the CD pipeline. Updating Corrosion fixes the issue. According to the error message and Corrosion's changelog, I think rustup changed the format of the file they use to locate available toolchains.