### PR TITLE
fix!: Update the AccessKit crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "accesskit"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "becf0eb5215b6ecb0a739c31c21bd83c4f326524c9b46b7e882d77559b60a529"
+checksum = "e25ae84c0260bdf5df07796d7cc4882460de26a2b406ec0e6c42461a723b271b"
 
 [[package]]
 name = "accesskit-c"
@@ -20,9 +20,9 @@ dependencies = [
 
 [[package]]
 name = "accesskit_atspi_common"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce9928251cd5651ae983a77aeaa528471eed47cf705885e0b03249b72fe4e8e1"
+checksum = "29bd41de2e54451a8ca0dd95ebf45b54d349d29ebceb7f20be264eee14e3d477"
 dependencies = [
  "accesskit",
  "accesskit_consumer",
@@ -34,20 +34,19 @@ dependencies = [
 
 [[package]]
 name = "accesskit_consumer"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0bf66a7bf0b7ea4fd7742d50b64782a88f99217cf246b3f93b4162528dde520"
+checksum = "8bfae7c152994a31dc7d99b8eeac7784a919f71d1b306f4b83217e110fd3824c"
 dependencies = [
  "accesskit",
  "hashbrown",
- "immutable-chunkmap",
 ]
 
 [[package]]
 name = "accesskit_macos"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09e230718177753b4e4ad9e1d9f6cfc2f4921212d4c1c480b253f526babb258d"
+checksum = "692dd318ff8a7a0ffda67271c4bd10cf32249656f4e49390db0b26ca92b095f2"
 dependencies = [
  "accesskit",
  "accesskit_consumer",
@@ -59,9 +58,9 @@ dependencies = [
 
 [[package]]
 name = "accesskit_unix"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ef06642e9f02f1708ad55e1eaeb8ad6956c22917699c4f313afa4f8f1b5e664"
+checksum = "c5f7474c36606d0fe4f438291d667bae7042ea2760f506650ad2366926358fc8"
 dependencies = [
  "accesskit",
  "accesskit_atspi_common",
@@ -77,9 +76,9 @@ dependencies = [
 
 [[package]]
 name = "accesskit_windows"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be08cadc069eaf5565fe82bbd6388e3bd66253e0b4f396311027660372d3d777"
+checksum = "70a042b62c9c05bf7b616f015515c17d2813f3ba89978d6f4fc369735d60700a"
 dependencies = [
  "accesskit",
  "accesskit_consumer",
@@ -88,12 +87,6 @@ dependencies = [
  "windows",
  "windows-core",
 ]
-
-[[package]]
-name = "arrayvec"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
 name = "async-broadcast"
@@ -512,15 +505,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "immutable-chunkmap"
-version = "2.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12f97096f508d54f8f8ab8957862eee2ccd628847b6217af1a335e1c44dee578"
-dependencies = [
- "arrayvec",
-]
-
-[[package]]
 name = "indexmap"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -923,32 +907,54 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.58.0"
+version = "0.61.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
+checksum = "c5ee8f3d025738cb02bad7868bbb5f8a6327501e870bf51f1b455b0a2454a419"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-link",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
  "windows-core",
- "windows-targets",
 ]
 
 [[package]]
 name = "windows-core"
-version = "0.58.0"
+version = "0.61.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+checksum = "4763c1de310c86d75a878046489e2e5ba02c649d185f21c67d4cf8a56d098980"
 dependencies = [
  "windows-implement",
  "windows-interface",
+ "windows-link",
  "windows-result",
  "windows-strings",
- "windows-targets",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a1d6bbefcb7b60acd19828e1bc965da6fcf18a7e39490c5f8be71e54a19ba32"
+dependencies = [
+ "windows-core",
+ "windows-link",
 ]
 
 [[package]]
 name = "windows-implement"
-version = "0.58.0"
+version = "0.60.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -957,9 +963,9 @@ dependencies = [
 
 [[package]]
 name = "windows-interface"
-version = "0.58.0"
+version = "0.59.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -967,22 +973,37 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-result"
+name = "windows-link"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+
+[[package]]
+name = "windows-numerics"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
- "windows-targets",
+ "windows-core",
+ "windows-link",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.1.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+checksum = "7a2ba9642430ee452d5a7aa78d72907ebe8cfda358e8cb7918a2050581322f97"
 dependencies = [
- "windows-result",
- "windows-targets",
+ "windows-link",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,16 +16,16 @@ doc = false
 cbindgen = []
 
 [dependencies]
-accesskit = "0.18.0"
+accesskit = "0.19.0"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-accesskit_windows = "0.26.0"
+accesskit_windows = "0.27.0"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-accesskit_macos = "0.19.0"
+accesskit_macos = "0.20.0"
 
 [target.'cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "openbsd", target_os = "netbsd"))'.dependencies]
-accesskit_unix = "0.14.0"
+accesskit_unix = "0.15.0"
 
 [profile.release]
 lto = true

--- a/include/accesskit.h
+++ b/include/accesskit.h
@@ -134,7 +134,6 @@ enum accesskit_has_popup
     : uint8_t
 #endif  // __cplusplus
 {
-  ACCESSKIT_HAS_POPUP_TRUE,
   ACCESSKIT_HAS_POPUP_MENU,
   ACCESSKIT_HAS_POPUP_LISTBOX,
   ACCESSKIT_HAS_POPUP_TREE,
@@ -988,12 +987,6 @@ bool accesskit_node_is_hidden(const struct accesskit_node *node);
 void accesskit_node_set_hidden(struct accesskit_node *node);
 
 void accesskit_node_clear_hidden(struct accesskit_node *node);
-
-bool accesskit_node_is_linked(const struct accesskit_node *node);
-
-void accesskit_node_set_linked(struct accesskit_node *node);
-
-void accesskit_node_clear_linked(struct accesskit_node *node);
 
 bool accesskit_node_is_multiselectable(const struct accesskit_node *node);
 
@@ -2234,6 +2227,15 @@ void accesskit_unix_adapter_free(struct accesskit_unix_adapter *adapter);
 
 #if (defined(__linux__) || defined(__DragonFly__) || defined(__FreeBSD__) || \
      defined(__NetBSD__) || defined(__OpenBSD__))
+/**
+ * Set the bounds of the top-level window. The outer bounds contain any
+ * window decoration and borders.
+ *
+ * # Caveats
+ *
+ * Since an application can not get the position of its window under
+ * Wayland, calling this method only makes sense under X11.
+ */
 void accesskit_unix_adapter_set_root_window_bounds(
     struct accesskit_unix_adapter *adapter, struct accesskit_rect outer,
     struct accesskit_rect inner);

--- a/src/common.rs
+++ b/src/common.rs
@@ -408,7 +408,6 @@ impl node {
 
 flag_methods! {
     (accesskit_node_is_hidden, is_hidden, accesskit_node_set_hidden, set_hidden, accesskit_node_clear_hidden, clear_hidden),
-    (accesskit_node_is_linked, is_linked, accesskit_node_set_linked, set_linked, accesskit_node_clear_linked, clear_linked),
     (accesskit_node_is_multiselectable, is_multiselectable, accesskit_node_set_multiselectable, set_multiselectable, accesskit_node_clear_multiselectable, clear_multiselectable),
     (accesskit_node_is_required, is_required, accesskit_node_set_required, set_required, accesskit_node_clear_required, clear_required),
     (accesskit_node_is_visited, is_visited, accesskit_node_set_visited, set_visited, accesskit_node_clear_visited, clear_visited),

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -47,6 +47,13 @@ impl unix_adapter {
         drop(box_from_ptr(adapter));
     }
 
+    /// Set the bounds of the top-level window. The outer bounds contain any
+    /// window decoration and borders.
+    ///
+    /// # Caveats
+    ///
+    /// Since an application can not get the position of its window under
+    /// Wayland, calling this method only makes sense under X11.
     #[no_mangle]
     pub extern "C" fn accesskit_unix_adapter_set_root_window_bounds(
         adapter: *mut unix_adapter,


### PR DESCRIPTION
Fixes #36 

## Breaking changes

- Drop redundant `ACCESSKIT_HAS_POPUP_TRUE`
- Drop unused `accesskit_node_is_linked`