### PR TITLE
meson: remove MSYS2 specific workaround for rust target selection

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -104,9 +104,7 @@ if host_system == 'windows'
   if is_msvc_style
     rustc_toolchain_cc = 'msvc'
   elif cc.get_id() == 'clang'
-    # https://github.com/msys2/MINGW-packages/issues/13388
-    is_msys2 = cc.get_define('__MINGW32__') == '1' and host_machine.cpu_family() != 'aarch64' and host_machine.system() in ['windows', 'cygwin']
-    rustc_toolchain_cc = is_msys2 ? 'gnu' : 'gnullvm'
+    rustc_toolchain_cc = 'gnullvm'
   else
     rustc_toolchain_cc = 'gnu'
   endif


### PR DESCRIPTION
In MSYS2 we used the gnu target even for llvm envs to work around the rust ecosystem not supporting that target.

7 months ago we switched to gnullvm, see
https://github.com/msys2/MINGW-packages/pull/21902

Remove the MSYS2 workaround to fix the build in MSYS2 llvm envs.

Same as https://gitlab.gnome.org/GNOME/librsvg/-/commit/22086fb38b9709116cced919fbd0ec0c7a828a6c which is likely where that code was copied from.