### PR TITLE
chore: Fix cbindgen header generation by pinning the nightly toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,9 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: install nightly toolchain
-      uses: dtolnay/rust-toolchain@nightly
+      uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: nightly-2025-03-27
 
     - uses: dtolnay/install@master
       with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ if (ACCESSKIT_BUILD_HEADERS)
     find_program(CLANG_FORMAT clang-format)
 
     add_custom_target(headers ALL
-        COMMAND ${RUSTUP} run nightly ${CBINDGEN} --crate accesskit-c --output accesskit.hpp "${CMAKE_SOURCE_DIR}"
+        COMMAND ${RUSTUP} run nightly-2025-03-27 ${CBINDGEN} --crate accesskit-c --output accesskit.hpp "${CMAKE_SOURCE_DIR}"
         COMMAND ${CLANG_FORMAT} -i accesskit.hpp
         COMMAND ${CMAKE_COMMAND} -E rename accesskit.hpp accesskit.h
         BYPRODUCTS accesskit.h

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ cmake -S . -B build -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_PROCESSOR=x86 -DRus
 
 If you modify the C bindings, you need to regenerate the header file and commit it. To do this, in addition to the above requirements, you will need:
 
-- A nightly Rust toolchain: `rustup install nightly`
+- A specific nightly Rust toolchain: `rustup install nightly-2025-03-27`
 - [cbindgen](https://github.com/mozilla/cbindgen): `cargo install cbindgen`
 - [clang-format](https://releases.llvm.org/14.0.0/tools/clang/docs/ClangFormat.html), version 14 or higher
 


### PR DESCRIPTION
I bisected and found the latest nightly toolchain where macro expansion correctly preserves the `cfg` attributes, meaning that `cbindgen` can turn them into preprocessor directives. I don't know what the proper, permanent fix for this is.