### PR TITLE
ci: Update GitHub Windows runners image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macOS-latest, windows-2019, ubuntu-latest]
+        os: [macOS-latest, windows-2025, ubuntu-latest]
     name: cargo clippy
     steps:
       - uses: actions/checkout@v4
@@ -88,7 +88,7 @@ jobs:
     needs: find-msrv
     strategy:
       matrix:
-        os: [macOS-latest, windows-2019, ubuntu-latest]
+        os: [macOS-latest, windows-2025, ubuntu-latest]
     name: cargo test
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,19 +19,19 @@ jobs:
             target: x86_64-apple-darwin
             cmake-options: -DCMAKE_OSX_ARCHITECTURES=x86_64
             path: macos/x86_64
-          - os: windows-2019
+          - os: windows-2025
             target: aarch64-pc-windows-msvc
-            setup-step: 'cmd.exe /k "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsamd64_x86.bat" `& powershell'
+            setup-step: 'cmd.exe /k "C:\Program Files (x86)\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsamd64_x86.bat" `& powershell'
             cmake-options: -A ARM64
             path: windows/arm64/msvc
-          - os: windows-2019
+          - os: windows-2025
             target: i686-pc-windows-msvc
-            setup-step: 'cmd.exe /k "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars32.bat" `& powershell'
+            setup-step: 'cmd.exe /k "C:\Program Files (x86)\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars32.bat" `& powershell'
             cmake-options: -A Win32
             path: windows/x86/msvc
-          - os: windows-2019
+          - os: windows-2025
             target: x86_64-pc-windows-msvc
-            setup-step: 'cmd.exe /k "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat" `& powershell'
+            setup-step: 'cmd.exe /k "C:\Program Files (x86)\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat" `& powershell'
             path: windows/x86_64/msvc
           - os: ubuntu-latest
             target: i686-pc-windows-gnu


### PR DESCRIPTION
`windows-2019` GitHub runner images [are being deprecated](https://github.com/actions/runner-images/issues/12045) and will stop working by the end of this month. Here I'm pinning to the `2025` version of the image since the next one will likely ship a different version of Visual Studio, which will have to be reflected in the workflow to publish the pre-built binaries.