### PR TITLE
SDL window is invisible and unselectable in Wayland Fedora

### DIFF
--- a/examples/sdl/hello_world.c
+++ b/examples/sdl/hello_world.c
@@ -374,7 +374,8 @@ int main(int argc, char *argv[]) {
         window_state_unlock(&state);
       }
     }
-    SDL_FillRect(screen_surface, NULL, SDL_MapRGB(&(*screen_surface->format), 0x00, 0x00, 0x00));
+    SDL_FillRect(screen_surface, NULL,
+                 SDL_MapRGB(&(*screen_surface->format), 0x00, 0x00, 0x00));
     SDL_UpdateWindowSurface(window);
   }
 


### PR DESCRIPTION
### Issue
SDL windows have a lot of trouble displaying properly in Wayland environments like Fedora, so much so that the SDL accesskit C-bindings example created an orphaned application that was unselectable and could not grab focus by the OS when running on Fedora 41 GNOME. 

This causes the SDL example to fail, because its impossible to focus on the invisible buttons in the invisible window.
No matter what I tried, ORCA would not respond and focus on the buttons.

### Sollution
By writing an all-black color to the Fill rect and updating the window surface with said rect, it forces the window to render. This also causes GNOME to render the window Decorator titled "hello world", which otherwise would not be rendered in this example.

This change also causes parity with the Windows OS example of accesskit and SDL, because the Windows example DOES create a black window containing the application example,

So this change is simply working around quirks and differences between the SDL handling of Windows, Linux Wayland and X11, and forces the app window to always be created.