### PR TITLE
Allow usage of slice-style strings rather than just null-sentinel strings

### DIFF
--- a/include/accesskit.h
+++ b/include/accesskit.h
@@ -1368,6 +1368,12 @@ char *accesskit_node_label(const struct accesskit_node *node);
  */
 void accesskit_node_set_label(struct accesskit_node *node, const char *value);
 
+/**
+ * Caller is responsible for freeing the memory pointed by `value`.
+ */
+void accesskit_node_set_label_with_length(struct accesskit_node *node,
+                                          const char *value, size_t length);
+
 void accesskit_node_clear_label(struct accesskit_node *node);
 
 /**
@@ -1381,6 +1387,13 @@ char *accesskit_node_description(const struct accesskit_node *node);
 void accesskit_node_set_description(struct accesskit_node *node,
                                     const char *value);
 
+/**
+ * Caller is responsible for freeing the memory pointed by `value`.
+ */
+void accesskit_node_set_description_with_length(struct accesskit_node *node,
+                                                const char *value,
+                                                size_t length);
+
 void accesskit_node_clear_description(struct accesskit_node *node);
 
 /**
@@ -1392,6 +1405,12 @@ char *accesskit_node_value(const struct accesskit_node *node);
  * Caller is responsible for freeing the memory pointed by `value`.
  */
 void accesskit_node_set_value(struct accesskit_node *node, const char *value);
+
+/**
+ * Caller is responsible for freeing the memory pointed by `value`.
+ */
+void accesskit_node_set_value_with_length(struct accesskit_node *node,
+                                          const char *value, size_t length);
 
 void accesskit_node_clear_value(struct accesskit_node *node);
 
@@ -1406,6 +1425,13 @@ char *accesskit_node_access_key(const struct accesskit_node *node);
 void accesskit_node_set_access_key(struct accesskit_node *node,
                                    const char *value);
 
+/**
+ * Caller is responsible for freeing the memory pointed by `value`.
+ */
+void accesskit_node_set_access_key_with_length(struct accesskit_node *node,
+                                               const char *value,
+                                               size_t length);
+
 void accesskit_node_clear_access_key(struct accesskit_node *node);
 
 /**
@@ -1418,6 +1444,12 @@ char *accesskit_node_author_id(const struct accesskit_node *node);
  */
 void accesskit_node_set_author_id(struct accesskit_node *node,
                                   const char *value);
+
+/**
+ * Caller is responsible for freeing the memory pointed by `value`.
+ */
+void accesskit_node_set_author_id_with_length(struct accesskit_node *node,
+                                              const char *value, size_t length);
 
 void accesskit_node_clear_author_id(struct accesskit_node *node);
 
@@ -1432,6 +1464,13 @@ char *accesskit_node_class_name(const struct accesskit_node *node);
 void accesskit_node_set_class_name(struct accesskit_node *node,
                                    const char *value);
 
+/**
+ * Caller is responsible for freeing the memory pointed by `value`.
+ */
+void accesskit_node_set_class_name_with_length(struct accesskit_node *node,
+                                               const char *value,
+                                               size_t length);
+
 void accesskit_node_clear_class_name(struct accesskit_node *node);
 
 /**
@@ -1444,6 +1483,13 @@ char *accesskit_node_font_family(const struct accesskit_node *node);
  */
 void accesskit_node_set_font_family(struct accesskit_node *node,
                                     const char *value);
+
+/**
+ * Caller is responsible for freeing the memory pointed by `value`.
+ */
+void accesskit_node_set_font_family_with_length(struct accesskit_node *node,
+                                                const char *value,
+                                                size_t length);
 
 void accesskit_node_clear_font_family(struct accesskit_node *node);
 
@@ -1458,6 +1504,12 @@ char *accesskit_node_html_tag(const struct accesskit_node *node);
 void accesskit_node_set_html_tag(struct accesskit_node *node,
                                  const char *value);
 
+/**
+ * Caller is responsible for freeing the memory pointed by `value`.
+ */
+void accesskit_node_set_html_tag_with_length(struct accesskit_node *node,
+                                             const char *value, size_t length);
+
 void accesskit_node_clear_html_tag(struct accesskit_node *node);
 
 /**
@@ -1470,6 +1522,13 @@ char *accesskit_node_inner_html(const struct accesskit_node *node);
  */
 void accesskit_node_set_inner_html(struct accesskit_node *node,
                                    const char *value);
+
+/**
+ * Caller is responsible for freeing the memory pointed by `value`.
+ */
+void accesskit_node_set_inner_html_with_length(struct accesskit_node *node,
+                                               const char *value,
+                                               size_t length);
 
 void accesskit_node_clear_inner_html(struct accesskit_node *node);
 
@@ -1484,6 +1543,12 @@ char *accesskit_node_keyboard_shortcut(const struct accesskit_node *node);
 void accesskit_node_set_keyboard_shortcut(struct accesskit_node *node,
                                           const char *value);
 
+/**
+ * Caller is responsible for freeing the memory pointed by `value`.
+ */
+void accesskit_node_set_keyboard_shortcut_with_length(
+    struct accesskit_node *node, const char *value, size_t length);
+
 void accesskit_node_clear_keyboard_shortcut(struct accesskit_node *node);
 
 /**
@@ -1496,6 +1561,12 @@ char *accesskit_node_language(const struct accesskit_node *node);
  */
 void accesskit_node_set_language(struct accesskit_node *node,
                                  const char *value);
+
+/**
+ * Caller is responsible for freeing the memory pointed by `value`.
+ */
+void accesskit_node_set_language_with_length(struct accesskit_node *node,
+                                             const char *value, size_t length);
 
 void accesskit_node_clear_language(struct accesskit_node *node);
 
@@ -1510,6 +1581,13 @@ char *accesskit_node_placeholder(const struct accesskit_node *node);
 void accesskit_node_set_placeholder(struct accesskit_node *node,
                                     const char *value);
 
+/**
+ * Caller is responsible for freeing the memory pointed by `value`.
+ */
+void accesskit_node_set_placeholder_with_length(struct accesskit_node *node,
+                                                const char *value,
+                                                size_t length);
+
 void accesskit_node_clear_placeholder(struct accesskit_node *node);
 
 /**
@@ -1522,6 +1600,12 @@ char *accesskit_node_role_description(const struct accesskit_node *node);
  */
 void accesskit_node_set_role_description(struct accesskit_node *node,
                                          const char *value);
+
+/**
+ * Caller is responsible for freeing the memory pointed by `value`.
+ */
+void accesskit_node_set_role_description_with_length(
+    struct accesskit_node *node, const char *value, size_t length);
 
 void accesskit_node_clear_role_description(struct accesskit_node *node);
 
@@ -1536,6 +1620,12 @@ char *accesskit_node_state_description(const struct accesskit_node *node);
 void accesskit_node_set_state_description(struct accesskit_node *node,
                                           const char *value);
 
+/**
+ * Caller is responsible for freeing the memory pointed by `value`.
+ */
+void accesskit_node_set_state_description_with_length(
+    struct accesskit_node *node, const char *value, size_t length);
+
 void accesskit_node_clear_state_description(struct accesskit_node *node);
 
 /**
@@ -1548,6 +1638,12 @@ char *accesskit_node_tooltip(const struct accesskit_node *node);
  */
 void accesskit_node_set_tooltip(struct accesskit_node *node, const char *value);
 
+/**
+ * Caller is responsible for freeing the memory pointed by `value`.
+ */
+void accesskit_node_set_tooltip_with_length(struct accesskit_node *node,
+                                            const char *value, size_t length);
+
 void accesskit_node_clear_tooltip(struct accesskit_node *node);
 
 /**
@@ -1559,6 +1655,12 @@ char *accesskit_node_url(const struct accesskit_node *node);
  * Caller is responsible for freeing the memory pointed by `value`.
  */
 void accesskit_node_set_url(struct accesskit_node *node, const char *value);
+
+/**
+ * Caller is responsible for freeing the memory pointed by `value`.
+ */
+void accesskit_node_set_url_with_length(struct accesskit_node *node,
+                                        const char *value, size_t length);
 
 void accesskit_node_clear_url(struct accesskit_node *node);
 
@@ -1573,6 +1675,13 @@ char *accesskit_node_row_index_text(const struct accesskit_node *node);
 void accesskit_node_set_row_index_text(struct accesskit_node *node,
                                        const char *value);
 
+/**
+ * Caller is responsible for freeing the memory pointed by `value`.
+ */
+void accesskit_node_set_row_index_text_with_length(struct accesskit_node *node,
+                                                   const char *value,
+                                                   size_t length);
+
 void accesskit_node_clear_row_index_text(struct accesskit_node *node);
 
 /**
@@ -1585,6 +1694,12 @@ char *accesskit_node_column_index_text(const struct accesskit_node *node);
  */
 void accesskit_node_set_column_index_text(struct accesskit_node *node,
                                           const char *value);
+
+/**
+ * Caller is responsible for freeing the memory pointed by `value`.
+ */
+void accesskit_node_set_column_index_text_with_length(
+    struct accesskit_node *node, const char *value, size_t length);
 
 void accesskit_node_clear_column_index_text(struct accesskit_node *node);
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -244,7 +244,7 @@ macro_rules! node_id_property_methods {
 }
 
 macro_rules! string_property_methods {
-    ($(($c_getter:ident, $getter:ident, $c_setter:ident, $setter:ident, $c_clearer:ident, $clearer:ident)),+) => {
+    ($(($c_getter:ident, $getter:ident, $c_setter:ident, $c_setter_with_length:ident, $setter:ident, $c_clearer:ident, $clearer:ident)),+) => {
         $(impl node {
             /// Caller must call `accesskit_string_free` with the return value.
             #[no_mangle]
@@ -261,6 +261,13 @@ macro_rules! string_property_methods {
                 let node = mut_from_ptr(node);
                 let value = unsafe { CStr::from_ptr(value) };
                 node.$setter(value.to_string_lossy());
+            }
+            /// Caller is responsible for freeing the memory pointed by `value`.
+            #[no_mangle]
+            pub extern "C" fn $c_setter_with_length(node: *mut node, value: *const c_char, length: usize) {
+                let node = mut_from_ptr(node);
+                let value = unsafe { slice::from_raw_parts(value as *const u8, length) };
+                node.$setter(String::from_utf8_lossy(value));
             }
         }
         clearer! { $c_clearer, $clearer })*
@@ -492,24 +499,24 @@ pub extern "C" fn accesskit_string_free(string: *mut c_char) {
 }
 
 string_property_methods! {
-    (accesskit_node_label, label, accesskit_node_set_label, set_label, accesskit_node_clear_label, clear_label),
-    (accesskit_node_description, description, accesskit_node_set_description, set_description, accesskit_node_clear_description, clear_description),
-    (accesskit_node_value, value, accesskit_node_set_value, set_value, accesskit_node_clear_value, clear_value),
-    (accesskit_node_access_key, access_key, accesskit_node_set_access_key, set_access_key, accesskit_node_clear_access_key, clear_access_key),
-    (accesskit_node_author_id, author_id, accesskit_node_set_author_id, set_author_id, accesskit_node_clear_author_id, clear_author_id),
-    (accesskit_node_class_name, class_name, accesskit_node_set_class_name, set_class_name, accesskit_node_clear_class_name, clear_class_name),
-    (accesskit_node_font_family, font_family, accesskit_node_set_font_family, set_font_family, accesskit_node_clear_font_family, clear_font_family),
-    (accesskit_node_html_tag, html_tag, accesskit_node_set_html_tag, set_html_tag, accesskit_node_clear_html_tag, clear_html_tag),
-    (accesskit_node_inner_html, inner_html, accesskit_node_set_inner_html, set_inner_html, accesskit_node_clear_inner_html, clear_inner_html),
-    (accesskit_node_keyboard_shortcut, keyboard_shortcut, accesskit_node_set_keyboard_shortcut, set_keyboard_shortcut, accesskit_node_clear_keyboard_shortcut, clear_keyboard_shortcut),
-    (accesskit_node_language, language, accesskit_node_set_language, set_language, accesskit_node_clear_language, clear_language),
-    (accesskit_node_placeholder, placeholder, accesskit_node_set_placeholder, set_placeholder, accesskit_node_clear_placeholder, clear_placeholder),
-    (accesskit_node_role_description, role_description, accesskit_node_set_role_description, set_role_description, accesskit_node_clear_role_description, clear_role_description),
-    (accesskit_node_state_description, state_description, accesskit_node_set_state_description, set_state_description, accesskit_node_clear_state_description, clear_state_description),
-    (accesskit_node_tooltip, tooltip, accesskit_node_set_tooltip, set_tooltip, accesskit_node_clear_tooltip, clear_tooltip),
-    (accesskit_node_url, url, accesskit_node_set_url, set_url, accesskit_node_clear_url, clear_url),
-    (accesskit_node_row_index_text, row_index_text, accesskit_node_set_row_index_text, set_row_index_text, accesskit_node_clear_row_index_text, clear_row_index_text),
-    (accesskit_node_column_index_text, column_index_text, accesskit_node_set_column_index_text, set_column_index_text, accesskit_node_clear_column_index_text, clear_column_index_text)
+    (accesskit_node_label, label, accesskit_node_set_label, accesskit_node_set_label_with_length, set_label, accesskit_node_clear_label, clear_label),
+    (accesskit_node_description, description, accesskit_node_set_description, accesskit_node_set_description_with_length, set_description, accesskit_node_clear_description, clear_description),
+    (accesskit_node_value, value, accesskit_node_set_value, accesskit_node_set_value_with_length, set_value, accesskit_node_clear_value, clear_value),
+    (accesskit_node_access_key, access_key, accesskit_node_set_access_key, accesskit_node_set_access_key_with_length, set_access_key, accesskit_node_clear_access_key, clear_access_key),
+    (accesskit_node_author_id, author_id, accesskit_node_set_author_id, accesskit_node_set_author_id_with_length, set_author_id, accesskit_node_clear_author_id, clear_author_id),
+    (accesskit_node_class_name, class_name, accesskit_node_set_class_name, accesskit_node_set_class_name_with_length, set_class_name, accesskit_node_clear_class_name, clear_class_name),
+    (accesskit_node_font_family, font_family, accesskit_node_set_font_family, accesskit_node_set_font_family_with_length, set_font_family, accesskit_node_clear_font_family, clear_font_family),
+    (accesskit_node_html_tag, html_tag, accesskit_node_set_html_tag, accesskit_node_set_html_tag_with_length, set_html_tag, accesskit_node_clear_html_tag, clear_html_tag),
+    (accesskit_node_inner_html, inner_html, accesskit_node_set_inner_html, accesskit_node_set_inner_html_with_length, set_inner_html, accesskit_node_clear_inner_html, clear_inner_html),
+    (accesskit_node_keyboard_shortcut, keyboard_shortcut, accesskit_node_set_keyboard_shortcut, accesskit_node_set_keyboard_shortcut_with_length, set_keyboard_shortcut, accesskit_node_clear_keyboard_shortcut, clear_keyboard_shortcut),
+    (accesskit_node_language, language, accesskit_node_set_language, accesskit_node_set_language_with_length, set_language, accesskit_node_clear_language, clear_language),
+    (accesskit_node_placeholder, placeholder, accesskit_node_set_placeholder, accesskit_node_set_placeholder_with_length, set_placeholder, accesskit_node_clear_placeholder, clear_placeholder),
+    (accesskit_node_role_description, role_description, accesskit_node_set_role_description, accesskit_node_set_role_description_with_length, set_role_description, accesskit_node_clear_role_description, clear_role_description),
+    (accesskit_node_state_description, state_description, accesskit_node_set_state_description, accesskit_node_set_state_description_with_length, set_state_description, accesskit_node_clear_state_description, clear_state_description),
+    (accesskit_node_tooltip, tooltip, accesskit_node_set_tooltip, accesskit_node_set_tooltip_with_length, set_tooltip, accesskit_node_clear_tooltip, clear_tooltip),
+    (accesskit_node_url, url, accesskit_node_set_url, accesskit_node_set_url_with_length, set_url, accesskit_node_clear_url, clear_url),
+    (accesskit_node_row_index_text, row_index_text, accesskit_node_set_row_index_text, accesskit_node_set_row_index_text_with_length, set_row_index_text, accesskit_node_clear_row_index_text, clear_row_index_text),
+    (accesskit_node_column_index_text, column_index_text, accesskit_node_set_column_index_text, accesskit_node_set_column_index_text_with_length, set_column_index_text, accesskit_node_clear_column_index_text, clear_column_index_text)
 }
 
 f64_property_methods! {


### PR DESCRIPTION
This makes it so you can use strings that don't necessarily end with a null terminator. Useful for C libraries that offer that kind of API, or for bindings to languages other than C through the C binding.

Note: I'm not a Rust programmer, so I'm not sure if my implementation is the best (or most correct) one.