### PR TITLE
feat: Add functions to get string representation of opaque types

### DIFF
--- a/include/accesskit.h
+++ b/include/accesskit.h
@@ -2000,6 +2000,11 @@ struct accesskit_node *accesskit_node_new(accesskit_role role);
 
 void accesskit_node_free(struct accesskit_node *node);
 
+/**
+ * Caller must call `accesskit_string_free` with the return value.
+ */
+char *accesskit_node_debug(const struct accesskit_node *node);
+
 struct accesskit_tree *accesskit_tree_new(accesskit_node_id root);
 
 void accesskit_tree_free(struct accesskit_tree *tree);
@@ -2024,6 +2029,11 @@ void accesskit_tree_set_toolkit_version(struct accesskit_tree *tree,
 
 void accesskit_tree_clear_toolkit_version(struct accesskit_tree *tree);
 
+/**
+ * Caller must call `accesskit_string_free` with the return value.
+ */
+char *accesskit_tree_debug(const struct accesskit_tree *tree);
+
 struct accesskit_tree_update *accesskit_tree_update_with_focus(
     accesskit_node_id focus);
 
@@ -2047,6 +2057,12 @@ void accesskit_tree_update_clear_tree(struct accesskit_tree_update *update);
 
 void accesskit_tree_update_set_focus(struct accesskit_tree_update *update,
                                      accesskit_node_id focus);
+
+/**
+ * Caller must call `accesskit_string_free` with the return value.
+ */
+char *accesskit_tree_update_debug(
+    const struct accesskit_tree_update *tree_update);
 
 void accesskit_action_request_free(struct accesskit_action_request *request);
 
@@ -2214,6 +2230,14 @@ void *accesskit_macos_adapter_hit_test(
 
 #if defined(__APPLE__)
 /**
+ * Caller must call `accesskit_string_free` with the return value.
+ */
+char *accesskit_macos_adapter_debug(
+    const struct accesskit_macos_adapter *adapter);
+#endif
+
+#if defined(__APPLE__)
+/**
  * # Safety
  *
  * `view` must be a valid, unreleased pointer to an `NSView`.
@@ -2347,6 +2371,15 @@ void accesskit_unix_adapter_update_window_focus_state(
     struct accesskit_unix_adapter *adapter, bool is_focused);
 #endif
 
+#if (defined(__linux__) || defined(__DragonFly__) || defined(__FreeBSD__) || \
+     defined(__NetBSD__) || defined(__OpenBSD__))
+/**
+ * Caller must call `accesskit_string_free` with the return value.
+ */
+char *accesskit_unix_adapter_debug(
+    const struct accesskit_unix_adapter *adapter);
+#endif
+
 #if defined(_WIN32)
 /**
  * Memory is also freed when calling this function.
@@ -2395,6 +2428,14 @@ struct accesskit_opt_lresult accesskit_windows_adapter_handle_wm_getobject(
     struct accesskit_windows_adapter *adapter, WPARAM wparam, LPARAM lparam,
     accesskit_activation_handler_callback activation_handler,
     void *activation_handler_userdata);
+#endif
+
+#if defined(_WIN32)
+/**
+ * Caller must call `accesskit_string_free` with the return value.
+ */
+char *accesskit_windows_adapter_debug(
+    const struct accesskit_windows_adapter *adapter);
 #endif
 
 #if defined(_WIN32)

--- a/src/common.rs
+++ b/src/common.rs
@@ -3,13 +3,16 @@
 // the LICENSE-APACHE file) or the MIT license (found in
 // the LICENSE-MIT file), at your option.
 
-use crate::{box_from_ptr, mut_from_ptr, opt_struct, ref_from_ptr, BoxCastPtr, CastPtr};
 use accesskit::*;
 use std::{
     ffi::{CStr, CString},
     mem,
     os::raw::{c_char, c_void},
     ptr, slice,
+};
+
+use crate::{
+    box_from_ptr, debug_repr_from_ptr, mut_from_ptr, opt_struct, ref_from_ptr, BoxCastPtr, CastPtr,
 };
 
 pub struct node {
@@ -735,6 +738,12 @@ impl node {
     pub extern "C" fn accesskit_node_free(node: *mut node) {
         drop(box_from_ptr(node));
     }
+
+    /// Caller must call `accesskit_string_free` with the return value.
+    #[no_mangle]
+    pub extern "C" fn accesskit_node_debug(node: *const node) -> *mut c_char {
+        debug_repr_from_ptr(node)
+    }
 }
 
 pub struct tree {
@@ -812,6 +821,12 @@ impl tree {
         let tree = mut_from_ptr(tree);
         tree.toolkit_version = None;
     }
+
+    /// Caller must call `accesskit_string_free` with the return value.
+    #[no_mangle]
+    pub extern "C" fn accesskit_tree_debug(tree: *const tree) -> *mut c_char {
+        debug_repr_from_ptr(tree)
+    }
 }
 
 pub struct tree_update {
@@ -882,6 +897,12 @@ impl tree_update {
     pub extern "C" fn accesskit_tree_update_set_focus(update: *mut tree_update, focus: node_id) {
         let update = mut_from_ptr(update);
         update.focus = focus.into();
+    }
+
+    /// Caller must call `accesskit_string_free` with the return value.
+    #[no_mangle]
+    pub extern "C" fn accesskit_tree_update_debug(tree_update: *const tree_update) -> *mut c_char {
+        debug_repr_from_ptr(tree_update)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,11 @@ mod unix;
 #[cfg(any(target_os = "windows", feature = "cbindgen"))]
 mod windows;
 
+use std::{
+    ffi::{c_char, CString},
+    fmt::Debug,
+};
+
 pub use common::*;
 pub use geometry::*;
 #[cfg(any(target_os = "macos", feature = "cbindgen"))]
@@ -175,4 +180,14 @@ macro_rules! opt_struct {
             }
         }
     };
+}
+
+pub(crate) fn debug_repr_from_ptr<F, T>(value: *const F) -> *mut c_char
+where
+    F: CastConstPtr<RustType = T>,
+    T: Debug,
+{
+    let value = ref_from_ptr(value);
+    let debug_repr = format!("{:?}", value);
+    CString::new(debug_repr).unwrap().into_raw()
 }

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -3,17 +3,15 @@
 // the LICENSE-APACHE file) or the MIT license (found in
 // the LICENSE-MIT file), at your option.
 
-use crate::{
-    box_from_ptr, mut_from_ptr, tree_update_factory, tree_update_factory_userdata,
-    ActionHandlerCallback, ActivationHandlerCallback, BoxCastPtr, CastPtr, FfiActionHandler,
-    FfiActivationHandler,
-};
 use accesskit_macos::{
     add_focus_forwarder_to_window_class, Adapter, NSPoint, QueuedEvents, SubclassingAdapter,
 };
-use std::{
-    ffi::CStr,
-    os::raw::{c_char, c_void},
+use std::ffi::{c_char, c_void, CStr};
+
+use crate::{
+    box_from_ptr, debug_repr_from_ptr, mut_from_ptr, tree_update_factory,
+    tree_update_factory_userdata, ActionHandlerCallback, ActivationHandlerCallback, BoxCastPtr,
+    CastPtr, FfiActionHandler, FfiActivationHandler,
 };
 
 pub struct macos_queued_events {
@@ -133,6 +131,12 @@ impl macos_adapter {
         let mut activation_handler =
             FfiActivationHandler::new(activation_handler, activation_handler_userdata);
         adapter.hit_test(NSPoint::new(x, y), &mut activation_handler) as *mut _
+    }
+
+    /// Caller must call `accesskit_string_free` with the return value.
+    #[no_mangle]
+    pub extern "C" fn accesskit_macos_adapter_debug(adapter: *const macos_adapter) -> *mut c_char {
+        debug_repr_from_ptr(adapter)
     }
 }
 

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -3,14 +3,16 @@
 // the LICENSE-APACHE file) or the MIT license (found in
 // the LICENSE-MIT file), at your option.
 
-use crate::{
-    box_from_ptr, mut_from_ptr, tree_update_factory, tree_update_factory_userdata,
-    ActionHandlerCallback, ActivationHandlerCallback, BoxCastPtr, CastPtr,
-    DeactivationHandlerCallback, FfiActionHandler, FfiActivationHandler, FfiDeactivationHandler,
-};
 use accesskit::Rect;
 use accesskit_unix::Adapter;
-use std::os::raw::c_void;
+use std::ffi::{c_char, c_void};
+
+use crate::{
+    box_from_ptr, debug_repr_from_ptr, mut_from_ptr, tree_update_factory,
+    tree_update_factory_userdata, ActionHandlerCallback, ActivationHandlerCallback, BoxCastPtr,
+    CastPtr, DeactivationHandlerCallback, FfiActionHandler, FfiActivationHandler,
+    FfiDeactivationHandler,
+};
 
 pub struct unix_adapter {
     _private: [u8; 0],
@@ -84,5 +86,11 @@ impl unix_adapter {
     ) {
         let adapter = mut_from_ptr(adapter);
         adapter.update_window_focus_state(is_focused);
+    }
+
+    /// Caller must call `accesskit_string_free` with the return value.
+    #[no_mangle]
+    pub extern "C" fn accesskit_unix_adapter_debug(adapter: *const unix_adapter) -> *mut c_char {
+        debug_repr_from_ptr(adapter)
     }
 }

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -3,13 +3,14 @@
 // the LICENSE-APACHE file) or the MIT license (found in
 // the LICENSE-MIT file), at your option.
 
-use crate::{
-    box_from_ptr, mut_from_ptr, opt_struct, tree_update_factory, tree_update_factory_userdata,
-    ActionHandlerCallback, ActivationHandlerCallback, BoxCastPtr, CastPtr, FfiActionHandler,
-    FfiActivationHandler,
-};
 use accesskit_windows::*;
-use std::os::raw::c_void;
+use std::ffi::{c_char, c_void};
+
+use crate::{
+    box_from_ptr, debug_repr_from_ptr, mut_from_ptr, opt_struct, tree_update_factory,
+    tree_update_factory_userdata, ActionHandlerCallback, ActivationHandlerCallback, BoxCastPtr,
+    CastPtr, FfiActionHandler, FfiActivationHandler,
+};
 
 pub struct windows_queued_events {
     _private: [u8; 0],
@@ -101,6 +102,14 @@ impl windows_adapter {
             FfiActivationHandler::new(activation_handler, activation_handler_userdata);
         let lresult = adapter.handle_wm_getobject(wparam, lparam, &mut activation_handler);
         opt_lresult::from(lresult)
+    }
+
+    /// Caller must call `accesskit_string_free` with the return value.
+    #[no_mangle]
+    pub extern "C" fn accesskit_windows_adapter_debug(
+        adapter: *const windows_adapter,
+    ) -> *mut c_char {
+        debug_repr_from_ptr(adapter)
     }
 }
 


### PR DESCRIPTION
It can be useful to show the content of the opaque Rust types when troubleshooting. A function returning a string containing the Rust debug representation have been added to all the opaque types that implement the Debug trait.