### PR TITLE
fix: Fix Windows binary publishing jobs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,16 +34,17 @@ jobs:
           - os: windows-2025
             target: aarch64-pc-windows-msvc
             setup-step: 'cmd.exe /k "C:\Program Files (x86)\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsamd64_x86.bat" `& powershell'
-            cmake-options: -A ARM64
+            cmake-options: -A ARM64 -DCMAKE_CONFIGURATION_TYPES=Release
             path: windows/arm64/msvc
           - os: windows-2025
             target: i686-pc-windows-msvc
             setup-step: 'cmd.exe /k "C:\Program Files (x86)\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars32.bat" `& powershell'
-            cmake-options: -A Win32
+            cmake-options: -A Win32 -DCMAKE_CONFIGURATION_TYPES=Release
             path: windows/x86/msvc
           - os: windows-2025
             target: x86_64-pc-windows-msvc
             setup-step: 'cmd.exe /k "C:\Program Files (x86)\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat" `& powershell'
+            cmake-options: -DCMAKE_CONFIGURATION_TYPES=Release
             path: windows/x86_64/msvc
           - os: ubuntu-latest
             target: i686-pc-windows-gnu

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,7 @@ if (ACCESSKIT_BUILD_LIBRARIES)
 
     install(FILES
         "$<TARGET_PROPERTY:accesskit-shared,IMPORTED_LOCATION>"
-        "$<$<STREQUAL:${_accesskit_toolchain},msvc>:${CMAKE_CURRENT_BINARY_DIR}/accesskit.pdb>"
+        "$<$<STREQUAL:${_accesskit_toolchain},msvc>:$<TARGET_FILE_DIR:accesskit-shared>/accesskit.pdb>"
         DESTINATION "${ACCESSKIT_LIBRARIES_DIR}/shared"
     )
     install(FILES


### PR DESCRIPTION
Unsure exactly why this broke now: new CMake version or new Windows image for the runners are my best guess.

Tested on a fork.

Should we recreate the v0.22.0 release or just publish 0.22.1, leaving 0.22.0 without the assets?